### PR TITLE
Ejercicio 6

### DIFF
--- a/Prácticas/Soluciones/Práctica 7.md
+++ b/Prácticas/Soluciones/Práctica 7.md
@@ -102,7 +102,6 @@ $ I \equiv (|s| = |S_0| \wedge (0 \leq i \leq |s|/2)) \wedge_L subseq(s, 0, |s|-
 
 Mirando el invariante, veo que en cada iteración se duplican dos elementos de la secuencia y lo hace desde el final hacia adelante.
 
-Creo que el invariante no es correcto pues para $i = 0$ el para todo del invariante se indefine. Lo voy a resolver con un $<$ estricto.
 
 ```C++
 vector<int> duplicarElementos(vector<int> s) {
@@ -111,6 +110,7 @@ vector<int> duplicarElementos(vector<int> s) {
     while (i < s.size() / 2) {
         result[s.size() - 2*i - 1] = s[s.size() - 2*i - 1] * 2;
         result[s.size() - 2*i - 2] = s[s.size() - 2*i - 2] * 2;
+        i++;
     }
     return result;
 }

--- a/Prácticas/Soluciones/Práctica 7.md
+++ b/Prácticas/Soluciones/Práctica 7.md
@@ -108,9 +108,9 @@ vector<int> duplicarElementos(vector<int> s) {
     vector<int> result(s.size());
     int i = 0;
     while (i < s.size() / 2) {
-        result[s.size() - 2*i - 1] = s[s.size() - 2*i - 1] * 2;
-        result[s.size() - 2*i - 2] = s[s.size() - 2*i - 2] * 2;
         i++;
+        result[s.size() - 2*i + 1] = s[s.size() - 2*i - 1] * 2;
+        result[s.size() - 2*i + 2] = s[s.size() - 2*i - 2] * 2;
     }
     return result;
 }


### PR DESCRIPTION
El invariante está bien, el para todo no se indefine pues con i=0, el rango te queda vació y no se indefine, te queda falso pues |s| < |s| es falso. Se dice que es "falso por vacuidad". Además, pequeño detalle, faltaba poner el i++ en el programa.